### PR TITLE
Use std termios

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Things I remember about this editor:
     not be this simple though.
   * There is also a terminal backend for this *framework*
 * It nearly has no dependencies, only relying on glibc for
-  [2 functions](https://github.com/Hejsil/zte/blob/master/src/c.zig).
+  [1 function](https://github.com/Hejsil/zte/blob/master/src/c.zig).
 
 ![demo](demo.gif)
 

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,7 +1,5 @@
-// TODO: We only use two functions from libc. I'm sure Zig will get them
-//       (or at least ioctl) to it's std in the future, so look out for
-//       that
+// TODO: We only use one function from libc. I'm sure Zig will get it
+//       to it's std in the future, so look out for that
 pub usingnamespace @cImport({
     @cInclude("sys/ioctl.h");
-    @cInclude("termios.h");
 });

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -1,12 +1,12 @@
 const std = @import("std");
 
 const c = @import("c.zig");
-const os = std.os;
 const vt100 = @import("vt100.zig");
 
 const fmt = std.fmt;
 const fs = std.fs;
 const mem = std.mem;
+const os = std.os;
 
 var old_tc_attr: ?os.termios = null;
 
@@ -92,8 +92,8 @@ fn enableRawMode(file: fs.File) !void {
     raw.oflag &= ~@as(@TypeOf(raw.lflag), os.OPOST);
     raw.cflag &= ~@as(@TypeOf(raw.lflag), os.CS8);
     raw.lflag &= ~@as(@TypeOf(raw.lflag), os.ECHO | os.ICANON | os.IEXTEN | os.ISIG);
-    raw.cc[5] = 0;
-    raw.cc[7] = 1;
+    raw.cc[VMIN] = 0;
+    raw.cc[VTIME] = 1;
     try os.tcsetattr(file.handle, os.TCSA.FLUSH, raw);
 }
 

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -98,15 +98,10 @@ fn enableRawMode(file: fs.File) !void {
 }
 
 fn getAttr(file: fs.File) !os.termios {
-    //    var raw: os.termios = undefined;
-    //    if (os.tcgetattr(file.handle, &raw) == -1)
-    //        return error.TermiosError;
     return try os.tcgetattr(file.handle);
 }
 
 fn setAttr(file: fs.File, attr: os.termios) !void {
-    //    if (os.tcsetattr(file.handle, os.TCSA.FLUSH, &attr) == -1)
-    //        return error.TermiosError;
     try os.tcsetattr(file.handle, os.TCSA.FLUSH, attr);
 }
 


### PR DESCRIPTION
Previously libc was required for using functions such as `tcgetattr` and `tcsetattr`, but now that those functions are available in the Zig standard library, dependence on libc for them is no longer necessary.